### PR TITLE
Fix `thread` function of sync coroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ local thread = co.create(function ()
   local x = co.yield(1)
   print(x)
   local y, z = co.yield(2, 3)
-  print(y)
+  print(y, z)
 end)
 
 pong(thread)

--- a/README.md
+++ b/README.md
@@ -214,12 +214,12 @@ local echo = function (...)
   return thunk
 end
 
-local thread = co.create(function ()
+local thread = function ()
   local x, y, z = co.yield(echo(1, 2, 3))
   print(x, y, z)
   local k, f, c = co.yield(echo(4, 5, 6))
   print(k, f, c)
-end)
+end
 
 pong(thread)
 ```


### PR DESCRIPTION
Sorry if I've got this completely wrong!

I don't think the expected printed values of the sync coroutines function `thread` match up.

https://github.com/ms-jpq/lua-async-await/blob/a54c07887056999fe44b642e7124381a8dcbaefd/README.md#L118-L123
https://github.com/ms-jpq/lua-async-await/blob/a54c07887056999fe44b642e7124381a8dcbaefd/README.md#L128