### PR TITLE
Add support for multiple return values in a.sync

### DIFF
--- a/lua/async.lua
+++ b/lua/async.lua
@@ -11,12 +11,16 @@ local pong = function (func, callback)
   local thread = co.create(func)
   local step = nil
   step = function (...)
-    local stat, ret = co.resume(thread, ...)
-    assert(stat, ret)
+    local pack = {co.resume(thread, ...)}
+    local status = pack[1]
+    local ret = pack[2]
+    assert(status, ret)
     if co.status(thread) == "dead" then
-      (callback or function () end)(ret)
+        if (callback) then 
+            (function (_, ...) callback(...) end)(table.unpack(pack))
+        end
     else
-      assert(type(ret) == "function", "type error :: expected func")
+      assert(type(ret) == "function", "type error :: expected func - coroutine yielded some value")
       ret(step)
     end
   end


### PR DESCRIPTION
* Currently this snippet prints `1, nil`. This is in contrast to `a.wrap` which does allow to call callback with multiple values
```lua
local func = a.sync(function()
    return 1, 2
end)

local entry = a.sync(function()
    local a, b = a.wait(func())
    print(a, b)
end)

entry()
```
* This patch will allow multiple return values: `1, 2` printed
