### PR TITLE
unpack() back/forward compat

### DIFF
--- a/lua/async.lua
+++ b/lua/async.lua
@@ -3,7 +3,7 @@
 --#################### ############ ####################
 
 local co = coroutine
-
+local unpack = table.unpack or unpack
 
 -- use with wrap
 local pong = function (func, callback)
@@ -17,7 +17,7 @@ local pong = function (func, callback)
     assert(status, ret)
     if co.status(thread) == "dead" then
         if (callback) then 
-            (function (_, ...) callback(...) end)(table.unpack(pack))
+            (function (_, ...) callback(...) end)(unpack(pack))
         end
     else
       assert(type(ret) == "function", "type error :: expected func - coroutine yielded some value")


### PR DESCRIPTION
* This PR allows lua-async to be freely used in 5.4 without using deprecated `unpack()`
* In my last PR I accidentally used `table.unpack()`, which is the `unpack()` alternative for lua 5.3+. `table.unpack` *MAY* be unavailable in lua 5.1 used in nvim